### PR TITLE
discv5-enr-lookup

### DIFF
--- a/discv5/src/discv5.nim
+++ b/discv5/src/discv5.nim
@@ -30,7 +30,7 @@ const
     LOOK_FOR_FIELD = true
 
     # The amount of nodes that will have our specific field to look for
-    LOOKUP_FIELD_DISTRIBUTION = 100
+    LOOKUP_FIELD_DISTRIBUTION = 5
 
 proc write(str: string) =
     if VERBOSE:

--- a/discv5/src/discv5.nim
+++ b/discv5/src/discv5.nim
@@ -107,7 +107,7 @@ proc runWithENR(node: discv5_protocol.Protocol, nodes: seq[discv5_protocol.Proto
             x.record.toUri() != node.localNode.record.toUri() and not called.contains(x.record.toUri())
         )
 
-        if lookup.countIt(it.record.tryGet("search", uint).isSome) >= 1:
+        if lookup.countIt(it.record.tryGet("search", seq[byte]).isSome) >= 1:
             echo i + 1
             return
 

--- a/discv5/src/utils.nim
+++ b/discv5/src/utils.nim
@@ -14,9 +14,25 @@ proc localAddress*(port: int): Address =
         ip: parseIpAddress("127.0.0.1")
     )
 
-proc initDiscoveryNode*(privKey: PrivateKey, address: Address, bootstrapRecords: seq[Record]): discv5_protocol.Protocol =
+proc initDiscoveryNode*(privKey: PrivateKey, address: Address, bootstrapRecords: seq[Record], field: uint): discv5_protocol.Protocol =
     var db = DiscoveryDB.init(newMemoryDB())
     result = newProtocol(privKey, db, some(parseIpAddress("127.0.0.1")), address.tcpPort, address.udpPort, bootstrapRecords)
+    let old = result.localNode.record
+
+    if field == 1:
+        let enr = initRecord(
+            old.seqNum,
+            privKey,
+            {
+                "udp": uint32(address.udpPort),
+                "tcp": uint32(address.tcpPort),
+                "ip": [byte 127, 0, 0, 1],
+                "search": field
+             }
+        )
+
+        result.localNode.record = enr
+
     result.open()
 
 proc count*[T](s: openArray[T], pred: proc(x: T): bool {.closure.}): int


### PR DESCRIPTION
@kdeme so we seem to have a problem here, the field `some` is added to our ENR. This is successful, the node is started with that enr, however when we lookup and try to get `some` that field is always none which seems weird to me. Could this be another discv5 bug?

What I did to check:
 - Ensure that `node.localNode.record` is properly updated
 - Ensure that we receive a node that SHOULD contain this